### PR TITLE
Harden CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,12 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Set up Go 1.x
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: '1.25'
         id: go
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Build
         run: |


### PR DESCRIPTION
## Summary

Tighten the GitHub Actions workflows in this repo so they no longer depend on a long-lived `LGTM_GITHUB_TOKEN` PAT, and bring them in line with GitHub's hardening guidance.

- **Use the default `GITHUB_TOKEN` instead of a PAT** for in-repo operations. `GITHUB_USER` switches to `github.actor`.
- **Scope `GITHUB_TOKEN` to least privilege** at the job level. `release-tracker.yml` gets `contents: write` so the token can push commits/tags back to this repo.
- **Pin every action to a full-length commit SHA** with a trailing version comment, so floating tags like `@v4` can't be silently re-pointed.
- **Tag-triggered workflows** now check out with `fetch-depth: 1` + `fetch-tags: true` so the tag ref resolves without a full clone.
- **Bump outdated `actions/checkout@v1`** to `@v4.3.1` where it appeared.

## Test plan
- [ ] CI passes on this PR.
- [ ] Confirm `release-tracker` continues to push commits/tags on PR close.
- [ ] Confirm `release.yml` still functions on the next tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)